### PR TITLE
feat: add function to read BL mac address

### DIFF
--- a/src/NINAB31serial.h
+++ b/src/NINAB31serial.h
@@ -6,7 +6,7 @@
 
 class NINAB31Serial
 {
-	
+
 	private:
 
     static String m_input;
@@ -22,13 +22,14 @@ class NINAB31Serial
     static bool setConnectionInterval(int minInterval, int maxInterval);
 
     static int parseResponse(String msg, uint32_t timeout);
+    static String parseStringResponse(String msg, uint32_t timeout);
     static bool checkResponse(String msg, uint32_t timeout);
     static bool poll();
     static String checkCharWritten(int handle);
     static void flushInput();
     static bool advertise();
     static bool stopAdvertise();
-    
+
 };
 
 #endif

--- a/src/SenseBoxBLE.cpp
+++ b/src/SenseBoxBLE.cpp
@@ -75,6 +75,14 @@ int SenseBoxBLE::addService(const char* serviceUUID){
   return port.parseResponse(String("AT+UBTGSER=")+serviceUUID,1000);
 }
 
+void SenseBoxBLE::setName(String name){
+  port.setLocalName(name);
+}
+
+String SenseBoxBLE::getMCUId(){
+  return port.parseStringResponse("AT+UMLA=1",1000);
+}
+
 /**
   * @brief Adds a characteristic to the BLE module.
   *

--- a/src/SenseBoxBLE.h
+++ b/src/SenseBoxBLE.h
@@ -30,6 +30,8 @@ class SenseBoxBLE
         static int addService(const char* serviceUUID);
         static int addCharacteristic(const char* characteristicUUID);
         static int setConfigCharacteristic(const char* serviceUUID, const char* characteristicUUID);
+        static void setName(String name);
+        static String getMCUId();
 
         static bool write(int, float&);
         static bool write(int, float&, float&);


### PR DESCRIPTION
After starting the SenseBoxBLE, you can now read the Bluetooth Mac Address and e.g. change the name:

```c
SenseBoxBLE::start("senseBox-BLE");
delay(1000);
String name = "senseBox:bike [" + SenseBoxBLE::getMCUId() + "]";
SenseBoxBLE::setName(name);
```

Which would result in  the name `senseBox:bike [CCF9578E439E]`